### PR TITLE
Update pySerialTransfer dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--r requirements/requirements.txt
+-r requirements/requirements-prod.txt

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,7 +1,7 @@
 approxeng.input==2.4.0
 attrs==19.3.0
-black==0.0
-Click==7.0
+black
+Click
 entrypoints==0.3
 evdev==1.2.0
 flake8==3.7.9

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,2 +1,0 @@
--r common.txt
--e /home/pi/src/pySerialTransfer

--- a/requirements/requirements-prod.txt
+++ b/requirements/requirements-prod.txt
@@ -1,2 +1,2 @@
 -r common.txt
-pySerialTransfer==1.1.11
+pySerialTransfer==2.0.4


### PR DESCRIPTION
Fixes #4

Upgrade to the latest upstream release of pySerialTransfer now that
arbitrary byte data can be transmitted (so we don't need to maintain
our own fork)