### PR TITLE
don't expect ADC values in sensor payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 !.vscode/extensions.json
 *.code-workspace
 logs/*
+*.pyc

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ def send_motor_speed_message(link=None, left=0, right=0):
     link.send(len(payload))
 
 def receive_sensor_data(link=None):
-    fmt = 'f' * 8 + 'l' * 6 + 'f' * 3 + 'f' * 3 + 'h' * 4
+    fmt = 'f' * 8 + 'l' * 6 + 'f' * 3 + 'f' * 3
 
     response = array.array('B', link.rxBuff[:link.bytesRead]).tobytes()
 


### PR DESCRIPTION
Removes the 4 * shorts from the expected payload in `receive_sensor_data`
note that this PR needs merging at the same time that https://github.com/robberwick/tauradigm-teensy/pull/19 is merged